### PR TITLE
Fixed Map clicked event firing when Pin clicked on iOS

### DIFF
--- a/src/Xamarin.Forms.BetterMaps/Platforms/ios/MapRenderer.cs
+++ b/src/Xamarin.Forms.BetterMaps/Platforms/ios/MapRenderer.cs
@@ -355,11 +355,22 @@ namespace Xamarin.Forms.BetterMaps.iOS
         #region Map
         private void OnMapClicked(UITapGestureRecognizer recognizer)
         {
-            if (Element == null) return;
+            if (MapModel?.CanSendMapClicked() != true)
+                return;
 
-            var tapPoint = recognizer.LocationInView(Control);
-            var tapGPS = MapNative.ConvertPoint(tapPoint, Control);
-            MapModel.SendMapClicked(new Position(tapGPS.Latitude, tapGPS.Longitude));
+            var mapNative = MapNative;
+
+            var pinTapped = mapNative.Annotations
+                .Select(a => mapNative.ViewForAnnotation(a))
+                .Where(v => v != null)
+                .Any(v => v.PointInside(recognizer.LocationInView(v), null));
+
+            if (!pinTapped)
+            {
+                var tapPoint = recognizer.LocationInView(mapNative);
+                var tapGPS = mapNative.ConvertPoint(tapPoint, Control);
+                MapModel.SendMapClicked(new Position(tapGPS.Latitude, tapGPS.Longitude));
+            }
         }
 
         private void UpdateRegion()

--- a/src/Xamarin.Forms.BetterMaps/Shared/Map.cs
+++ b/src/Xamarin.Forms.BetterMaps/Shared/Map.cs
@@ -158,6 +158,8 @@ namespace Xamarin.Forms.BetterMaps
         public event EventHandler<PinClickedEventArgs> InfoWindowLongClicked;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool CanSendMapClicked() => MapClicked != null;
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SendMapClicked(Position position) => MapClicked?.Invoke(this, new MapClickedEventArgs(position));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Xamarin.Forms.BetterMaps/Xamarin.Forms.BetterMaps.csproj
+++ b/src/Xamarin.Forms.BetterMaps/Xamarin.Forms.BetterMaps.csproj
@@ -33,6 +33,7 @@ A more useful maps control for Android &#38; iOS, based off Xamarin.Forms.Maps.
     <PackageReleaseNotes>
 - Removed `HideInfoWindow` property from `PinClickedEventArgs`
 - Added `CanShowInfoWindow` property to `Pin`
+- Fixed `MapClicked` firing when Pin is clicked (iOS)
     </PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
#2

If a pin is selected on the map, the `MapClicked` event should not fire.