### PR TITLE
Use ValueTask for loading pin icon images

### DIFF
--- a/src/Xamarin.Forms.BetterMaps/Platforms/android/MapRenderer.cs
+++ b/src/Xamarin.Forms.BetterMaps/Platforms/android/MapRenderer.cs
@@ -298,7 +298,7 @@ namespace Xamarin.Forms.BetterMaps.Android
 
                 opts.SetIcon(BitmapDescriptorFactory.FromBitmap(BitmapEmpty.Value));
 
-                imageTask.ContinueWith(t =>
+                imageTask.AsTask().ContinueWith(t =>
                 {
                     if (t.IsCompletedSuccessfully && !tok.IsCancellationRequested)
                         ApplyBitmapToMarker(t.Result, pin, tok);
@@ -514,7 +514,7 @@ namespace Xamarin.Forms.BetterMaps.Android
                     var tok = cts.Token;
                     pin.ImageSourceCts = cts;
 
-                    imageTask.ContinueWith(t =>
+                    imageTask.AsTask().ContinueWith(t =>
                     {
                         if (t.IsCompletedSuccessfully && !tok.IsCancellationRequested)
                             ApplyBitmapToMarker(t.Result, pin, tok);
@@ -545,7 +545,7 @@ namespace Xamarin.Forms.BetterMaps.Android
                 setBitmap();
         }
 
-        protected virtual async Task<Bitmap> GetPinImageAsync(ImageSource imgSource, AndroidColor tint)
+        protected virtual async ValueTask<Bitmap> GetPinImageAsync(ImageSource imgSource, AndroidColor tint)
         {
             if (imgSource == null)
                 return default;
@@ -597,7 +597,7 @@ namespace Xamarin.Forms.BetterMaps.Android
             return image ?? await GetImageAsync(imgSource).ConfigureAwait(false);
         }
 
-        protected virtual async Task<Bitmap> GetImageAsync(ImageSource imgSource)
+        protected virtual async ValueTask<Bitmap> GetImageAsync(ImageSource imgSource)
         {
             await _imgCacheSemaphore.WaitAsync().ConfigureAwait(false);
 
@@ -627,7 +627,9 @@ namespace Xamarin.Forms.BetterMaps.Android
                 _imgCacheSemaphore.Release();
             }
 
-            return await (imageTask ?? Task.FromResult(default(Bitmap))).ConfigureAwait(false);
+            return imageTask != null
+                ? await imageTask.ConfigureAwait(false)
+                : default(Bitmap);
         }
 
         protected Marker GetMarkerForPin(Pin pin)

--- a/src/Xamarin.Forms.BetterMaps/Platforms/ios/MapRenderer.cs
+++ b/src/Xamarin.Forms.BetterMaps/Platforms/ios/MapRenderer.cs
@@ -231,7 +231,7 @@ namespace Xamarin.Forms.BetterMaps.iOS
                 {
                     mapPin.Image = UIImageEmpty.Value;
 
-                    imageTask.ContinueWith(t =>
+                    imageTask.AsTask().ContinueWith(t =>
                     {
                         if (t.IsCompletedSuccessfully && !tok.IsCancellationRequested)
                             ApplyUIImageToView(t.Result, mapPin, tok);
@@ -680,7 +680,7 @@ namespace Xamarin.Forms.BetterMaps.iOS
                             }
                             else
                             {
-                                imageTask.ContinueWith(t =>
+                                imageTask.AsTask().ContinueWith(t =>
                                 {
                                     if (t.IsCompletedSuccessfully && !tok.IsCancellationRequested)
                                         ApplyUIImageToView(t.Result, view, tok);
@@ -710,7 +710,7 @@ namespace Xamarin.Forms.BetterMaps.iOS
                 setImage();
         }
 
-        protected virtual async Task<UIImage> GetPinImageAsync(ImageSource imgSource, UIColor tint)
+        protected virtual async ValueTask<UIImage> GetPinImageAsync(ImageSource imgSource, UIColor tint)
         {
             if (imgSource == null)
                 return default;
@@ -766,7 +766,7 @@ namespace Xamarin.Forms.BetterMaps.iOS
             return image ?? await GetImageAsync(imgSource).ConfigureAwait(false);
         }
 
-        protected virtual async Task<UIImage> GetImageAsync(ImageSource imgSource)
+        protected virtual async ValueTask<UIImage> GetImageAsync(ImageSource imgSource)
         {
             await _imgCacheSemaphore.WaitAsync().ConfigureAwait(false);
 
@@ -796,7 +796,9 @@ namespace Xamarin.Forms.BetterMaps.iOS
                 _imgCacheSemaphore.Release();
             }
 
-            return await (imageTask ?? Task.FromResult(default(UIImage))).ConfigureAwait(false);
+            return imageTask != null
+                ? await imageTask.ConfigureAwait(false)
+                : default(UIImage);
         }
 
         protected Pin GetPinForAnnotation(IMKAnnotation annotation)

--- a/src/Xamarin.Forms.BetterMaps/Xamarin.Forms.BetterMaps.csproj
+++ b/src/Xamarin.Forms.BetterMaps/Xamarin.Forms.BetterMaps.csproj
@@ -34,6 +34,7 @@ A more useful maps control for Android &#38; iOS, based off Xamarin.Forms.Maps.
 - Removed `HideInfoWindow` property from `PinClickedEventArgs`
 - Added `CanShowInfoWindow` property to `Pin`
 - Fixed `MapClicked` firing when Pin is clicked (iOS)
+- The renderer methods `GetPinImageAsync` and `GetImageAsync` now return `ValueTask`
     </PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
Return `ValueTask` instead of `Task` for `GetPinImageAsync` and `GetImageAsync`.